### PR TITLE
ZCS-3326: Delegated admin cannot download the result of account migration CSV file

### DIFF
--- a/BulkProvision/js/ZaBulkImportXWizard.js
+++ b/BulkProvision/js/ZaBulkImportXWizard.js
@@ -471,7 +471,7 @@ ZaBulkImportXWizard.prototype.generateBulkFileCallback = function(params, resp) 
                 } else if (this._containedObject[ZaBulkProvision.A2_provAction] == ZaBulkProvision.ACTION_GENERATE_BULK_CSV) {
                     format = ZaBulkProvision.FILE_FORMAT_BULK_CSV;
                 }
-                this._localXForm.setInstanceValue(AjxMessageFormat.format("{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?action=getBulkFile&fileID={3}&fileFormat={4}", [
+                this._localXForm.setInstanceValue(AjxMessageFormat.format("{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?fileID={3}&fileFormat={4}", [
                         location.protocol, location.hostname, location.port, response.fileToken[0]._content, format ]), ZaBulkProvision.A2_generatedFileLink);
                 this.goPage(ZaBulkImportXWizard.STEP_DOWNLOAD_FILE);
                 this._button[DwtWizardDialog.FINISH_BUTTON].setEnabled(true);
@@ -590,11 +590,11 @@ ZaBulkImportXWizard.prototype.processBulkImportResponse = function(response) {
     var errorsFileLink = null;
     var sucessFileLink = null;
     if (status == ZaBulkProvision.iSTATUS_FINISHED || status == ZaBulkProvision.iSTATUS_ABORTED || status == ZaBulkProvision.iSTATUS_ERROR) {
-        sucessFileLink = AjxMessageFormat.format("{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?action=getBulkFile&fileID={3}&fileFormat=reportcsv", [ location.protocol,
+        sucessFileLink = AjxMessageFormat.format("{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?fileID={3}&fileFormat=reportcsv", [ location.protocol,
                 location.hostname, location.port, fileToken ]);
 
         if (errorCount > 0) {
-            errorsFileLink = AjxMessageFormat.format("{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?action=getBulkFile&fileID={3}&fileFormat=errorscsv", [ location.protocol,
+            errorsFileLink = AjxMessageFormat.format("{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?fileID={3}&fileFormat=errorscsv", [ location.protocol,
                     location.hostname, location.port, fileToken ]);
         }
     }

--- a/BulkProvision/js/ZaMigrationXWizard.js
+++ b/BulkProvision/js/ZaMigrationXWizard.js
@@ -90,7 +90,7 @@ ZaMigrationXWizard.prototype.generateBulkFileCallback = function(params, resp) {
             var response = resp.getResponse().Body.GenerateBulkProvisionFileFromLDAPResponse;
             if (response.fileToken && response.fileToken[0] && response.fileToken[0]._content) {
                 this._localXForm.setInstanceValue(AjxMessageFormat.format(
-                        "{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?action=getBulkFile&fileID={3}&fileFormat={4}", [ location.protocol,
+                        "{0}//{1}:{2}/service/extension/com_zimbra_bulkprovision/bulkdownload?fileID={3}&fileFormat={4}", [ location.protocol,
                                 location.hostname, location.port, response.fileToken[0]._content,
                                 ZaBulkProvision.FILE_FORMAT_MIGRATION_XML ]), ZaBulkProvision.A2_generatedFileLink);
                 this.goPage(ZaMigrationXWizard.STEP_DOWNLOAD_FILE);

--- a/BulkProvision/js/com_zimbra_bulkprovision.js
+++ b/BulkProvision/js/com_zimbra_bulkprovision.js
@@ -187,7 +187,7 @@ if (ZaSettings && ZaSettings.EnabledZimlet["com_zimbra_bulkprovision"]) {
         //TODO: need to filter out non account items, such as domain, etc.
         if (window.console && window.console.log)
             window.console.log("Download all the search result accounts ...");
-        var queryString = "?action=getSR";
+        var queryString = "";
         if (this._currentQuery) {
             queryString += "&q=" + AjxStringUtil.urlComponentEncode(this._currentQuery);
         }
@@ -200,6 +200,7 @@ if (ZaSettings && ZaSettings.EnabledZimlet["com_zimbra_bulkprovision"]) {
             queryString += "&types=" + AjxStringUtil.urlComponentEncode(this.searchTypes.join(","));
         }
 
-        window.open("/service/extension/com_zimbra_bulkprovision/bulkdownload" + queryString);
+        queryString = queryString.replace(/^&/, "?");
+        window.open("/service/extension/com_zimbra_bulkprovision/search_results_download" + queryString);
     }
 }


### PR DESCRIPTION
The following Pull Request changes REST API of importing accounts and downloading search results.
https://github.com/Zimbra/zm-bulkprovision-store/pull/1

This zimlet (UI code) needs to use new APIs.
- Regarding bulk provisioning (imporing accounts), "action" param is removed as follows:
(current API) /service/extension/com_zimbra_bulkprovision/bulkdownload?action=getBulkFile&fileID=xxxx&fileFormat=xxxx
(new API)     /service/extension/com_zimbra_bulkprovision/bulkdownload?fileID=xxxx&fileFormat=xxxx

- Regarding downloading search results, "action" param is removed and path is changed as follows:
(current API) /service/extension/com_zimbra_bulkprovision/bulkdownload?action=getSR&query=xxxx
(new API)     /service/extension/com_zimbra_bulkprovision/search_results_download?query=xxxx